### PR TITLE
Don't disable mlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ Generate the `vault.hcl` configuration file and store it in the `vault` configma
 
 ```
 cat > vault.hcl <<EOF
-disable_mlock = true
-
 listener "tcp" {
   address = "0.0.0.0:8200"
   tls_cert_file = "/etc/vault/tls/vault.pem"


### PR DESCRIPTION
You [gave the container IPC_LOCK](https://github.com/kelseyhightower/vault-on-google-kubernetes-engine/blob/d267b5db43cd8620e6e2fb76d444b76b3c336411/vault.yaml#L68-L71), so it can actually memlock