### PR TITLE
Use a newer version of vault

### DIFF
--- a/vault.yaml
+++ b/vault.yaml
@@ -88,7 +88,7 @@ spec:
                   name: vault
                   key: kms-key-id
         - name: vault
-          image: "vault:0.10.0"
+          image: "vault:0.10.3"
           env:
             - name: POD_IP
               valueFrom:


### PR DESCRIPTION
0.10.0 has many bugs that cause crashes during even basic tests. 0.10.3 is a lot more stable.