### PR TITLE
Tweak README.md for PROJECT_ID setting in zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In this section you will create a new GCP project and enable the APIs required b
 Generate a project ID:
 
 ```
-PROJECT_ID="vault-$(($(date +%s%N)/1000000))"
+PROJECT_ID="vault-$(($(date +%s%d)/1000000))"
 ```
 
 Create a new GCP project:


### PR DESCRIPTION
Use `%d` instead of `%N` to convert the string into a number.

Resolves https://github.com/kelseyhightower/vault-on-google-kubernetes-engine/issues/17